### PR TITLE
Add AI SOC microservice with Kafka bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+data/*.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,201 @@
+# AI-Augmented SOC: Modular LLM Architecture
+
+This document captures a modular, hierarchical LLM-powered architecture that extends the previously discussed AI-augmented SOC design. The system separates the three classic cyber-security teams—Red, Blue, and Purple—into specialised LLM suites orchestrated by a lightweight task router.
+
+## 1. High-Level Diagram
+```
++----------------------+      +----------------------+      +----------------------+
+|   Red Team LLMs      | ---> |   Orchestration Hub  | <--- |   Blue Team LLMs    |
+| (Attack-gen, Phishing,|      | (task router, queue, |      | (Alert-enrich,      |
+|  Malware-craft)      |      |  policy engine)      |      |  Incident-playbooks)|
++----------------------+      +----------------------+      +----------------------+
+                                 ^          |
+                                 |          v
+                         +---------------------------+
+                         |   Purple Team LLM (Meta)  |
+                         |  (Gap analysis, metric    |
+                         |   synthesis, model update)|
+                         +---------------------------+
+```
+
+All LLM suites read from and write to the central SIEM (Elastic/OpenSearch) and trigger SOAR playbooks via the orchestration hub. Each box represents one or more containerised LLM instances that can be swapped or scaled independently.
+
+## 2. Component Breakdown
+
+### 2.1 Red-Team LLM Suite
+
+| Instance           | Core Prompt / Role                                                                                     | Typical Output                                                                                                     | Integration Point                                          |
+|--------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| **Red-Gen**        | "You are a skilled penetration tester. Generate a realistic multi-stage attack against a macOS endpoint, using publicly known exploits and custom payloads." | Attack playbook, malicious binaries (base64), phishing collateral, C2 configuration.                                | Writes `red-scenarios-*` documents in the SIEM.            |
+| **Phish-LLM**      | "Compose a convincing spear-phishing email targeting a senior engineer, embedding a malicious link."  | Email body, subject line, encoded attachment.                                                                       | Augments scenarios with social-engineering vectors.        |
+| **Malware-Craft**  | "Produce a small macOS-compatible payload (Swift/Python) that exfiltrates `/Users/*/Documents` to a given C2 URL." | Source code, compile commands, payload hash.                                                                         | Stores artifacts linked to the scenario.                   |
+| **Adversary-Emulation** | "Translate MITRE ATT&CK technique T1059 (Command-Shell) into a macOS Bash one-liner usable in the scenario." | Command snippets, expected telemetry.                                                                               | Supports Blue-LLM detection generation.                    |
+
+**Deployment tip:** Run each instance in lightweight Docker/Podman containers on macOS using quantised models (e.g., Llama-3-8B-Chat-Q4_K_M). Quantisation reduces RAM to roughly 6 GB per container, allowing two to three instances on a modern M2 Max MacBook Pro.
+
+### 2.2 Blue-Team LLM Suite
+
+| Instance              | Core Prompt / Role                                                                                               | Typical Output                                                                 | Integration Point                                              |
+|-----------------------|------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| **Alert-Enricher**    | "Given the raw OSQuery process log below, identify whether it matches any known malicious behaviours from the attached red scenario." | Enriched alert JSON (`ml.red_match=true`, ATT&CK mapping).                     | Updates `alerts-*` documents in the SIEM.                      |
+| **Detection-Builder** | "From the red-scenario describing a PowerShell-like macOS script, synthesise a Sigma rule that detects its execution pattern." | Sigma/YAML detection rules mapped to Elastic/Kibana.                           | Auto-loads into the SIEM detection engine.                    |
+| **Playbook-Executor** | "If an alert with `ml.red_match=true` appears, generate a containment playbook (isolate device, kill process, collect memory dump)." | SOAR-compatible playbook JSON.                                                | Sent to SOAR platforms via webhook.                           |
+| **Forensic-Analyst**  | "Summarise the timeline of events from the SIEM for host Mac-1234 after the red scenario triggered."             | Narrative timeline, evidence list, recommended artefacts.                      | Attached to incident tickets.                                 |
+
+**Deployment tip:** Operate Blue-LLMs with a larger reasoning model (e.g., Mistral-7B-Instruct-v0.2) accelerated via `llama.cpp` + Metal on Apple Silicon.
+
+### 2.3 Purple-Team LLM Suite
+
+| Instance                | Core Prompt / Role                                                                                                     | Typical Output                                                 | Integration Point                        |
+|-------------------------|------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|-------------------------------------------|
+| **Gap-Analyzer**        | "Compare the red-scenario steps with the blue-team detection coverage. List any ATT&CK techniques that were not detected." | Gap report JSON with severity scores.                         | Writes to `purple-gaps-*` index.          |
+| **Metric-Synthesiser**  | "From the last 30 days of red-scenario executions and blue responses, compute detection-rate, MTTD, and MTTC."           | KPI dashboard JSON.                                            | Drives executive reporting dashboards.     |
+| **Model-Updater**       | "Based on the gap report, suggest a new prompt tweak for the Red-Gen LLM and a new rule tweak for the Blue-Alert-Enricher." | Updated prompt strings, version metadata.                     | Triggers CI/CD container redeployments.    |
+| **Adversary-Defender Dialogue** | "Simulate a conversation where the Red-LLM tries to bypass the newly added detection rule and the Blue-LLM counters." | Dialogue transcript for analyst training.                     | Optional enrichment material.              |
+
+**Deployment tip:** Purple-team tasks can leverage compact summarisation models (e.g., Phi-2-7B) because their inputs are already structured.
+
+## 3. Orchestration Hub (Task Router)
+
+A slim Python or Go service—deployed as a macOS Launch Agent—handles queueing, policy enforcement, and result aggregation:
+
+1. **Queue Management:** Redis Streams (or SQLite for single-node) maintain task queues per team.
+2. **Policy Engine:** Encodes rules such as triggering Alert-Enricher within 30 seconds of a new red scenario and auto-retraining Red-Gen when more than two gaps are reported.
+3. **Result Aggregation:** Normalises LLM responses back into SIEM indices for visibility.
+
+Example REST contract:
+
+```http
+POST /tasks
+{
+  "team": "red|blue|purple",
+  "type": "generate_scenario|enrich_alert|analyze_gap",
+  "payload": { ... }
+}
+```
+
+Responses are persisted in `task-results-*`, enabling Kibana dashboards that visualise the pipeline.
+
+## 4. End-to-End Data Flow
+
+1. **Red Scenario Generation:** The hub queues a `generate_scenario` task; Red-Gen returns a multi-stage attack captured in `red-scenarios-*`.
+2. **Simulation / Injection:** A simulator replays benign equivalents within macOS sandboxes or emits expected telemetry which is forwarded to the SIEM.
+3. **Blue-Team Enrichment:** Logs trigger the `enrich_alert` pipeline; Alert-Enricher adds `ml.red_match:true` plus ATT&CK annotations to `alerts-*`.
+4. **Automatic Containment:** SOAR monitors for `ml.red_match:true`, invokes Playbook-Executor, and executes the containment sequence (MDM isolation, process termination, memory capture).
+5. **Purple-Team Gap Analysis:** Post-incident, Gap-Analyzer creates a gap report and Metric-Synthesiser updates KPIs (detection rate, MTTD, MTTC).
+6. **Continuous Improvement:** Model-Updater writes refined prompts to Git, CI rebuilds Docker images, and subsequent scenarios inherit improvements.
+
+## 5. macOS-Centric Deployment Checklist
+
+| Step | Action | Command / Tool |
+|------|--------|----------------|
+| 1 | Install container runtime | `brew install colima docker` |
+| 2 | Pull quantised models | `./scripts/download.sh Llama-3-8B-Q4_K_M` |
+| 3 | Build LLM containers | Dockerfile embedding `llama.cpp` server and quantised model. |
+| 4 | Set up Redis | `docker run -d --name redis -p 6379:6379 redis:7-alpine` |
+| 5 | Deploy Orchestration Hub | `git clone ... && uvicorn main:app --host 0.0.0.0 --port 8000` |
+| 6 | Connect SIEM | Forward `red-scenarios-*`, `alerts-*`, `purple-gaps-*` to Elasticsearch. |
+| 7 | Integrate SOAR | Configure webhook to `http://localhost:8000/playbook`. |
+| 8 | Visualise | Build Kibana dashboards (scenario catalogue, enriched alerts, purple KPIs). |
+| 9 | Test | Run `./scripts/demo.sh` to execute a full cycle. |
+| 10 | Harden | Use read-only containers, encrypted APFS, rotate SIEM/SOAR keys every 90 days. |
+
+## 6. Scaling and Future Enhancements
+
+| Need | Extension |
+|------|-----------|
+| Higher throughput | Scale Red-Gen containers behind a load balancer; optionally adopt Llama-3-70B on dedicated GPU hardware exposed via gRPC. |
+| Cross-platform coverage | Add Windows and Linux-focused Red-LLMs while sharing Blue-LLM resources. |
+| Human-in-the-loop | Provide a web UI for approving or editing generated phishing content. |
+| Zero-trust integration | Use OTEL traces with signed JWTs so only authorised LLM instances ingest data. |
+| Model provenance | Store prompt, temperature, and model hash alongside each artifact in the SIEM. |
+| Adaptive adversary | Allow Purple-LLM to feed next-generation prompts to Red-Gen, forming a co-evolutionary loop. |
+
+## 7. Quick-Start Example
+
+```bash
+# 1️⃣ Run the built-in orchestration demo (spins up FastAPI + sample tasks)
+./scripts/demo.sh
+
+# 2️⃣ (Optional) Interact with the API manually
+curl -s http://127.0.0.1:8000/tasks | jq
+curl -s "http://127.0.0.1:8000/queue/next?team=red" | jq
+
+# 3️⃣ (Optional) Integrate with external LLM containers following Section 5.
+```
+
+## 8. AI SOC Microservice
+
+To complement the orchestration hub, the repository now includes an AI-powered SOC service located under `ai_soc/`. The service is a FastAPI application that ingests threat-intel feeds, behavioural telemetry, and human approvals, then generates actionable remediation plans and quota updates via an LLM-backed policy engine.
+
+### Capabilities
+
+- **Threat-Intel ingestion** – POST structured CTI events to `/threat-intel` to automatically raise alerts when new high/critical indicators are detected.
+- **Behavioural analytics** – Stream telemetry (or post JSON documents) to `/telemetry`; spikes in outbound activity trigger alerts enriched with contextual metadata.
+- **Automated response** – Every alert is paired with a remediation plan (policy patch + playbook steps) and an optional quota update that disables self-suggestion for malicious agents.
+- **Kafka integration** – When `KAFKA_BOOTSTRAP_SERVERS` is provided, the service consumes `rbp.metrics`, `rbp.proposals`, and `rbp.approvals`, then publishes alerts to `rbp.alerts` and quota updates to `rbp.quota_updates`.
+
+### Running the Service
+
+```bash
+# Start the AI SOC API on port 9000 (defaults can be overridden via env vars)
+./scripts/run_ai_soc.sh
+
+# Check health
+curl -s http://127.0.0.1:9000/healthz
+
+# Inject a telemetry spike
+curl -s -X POST http://127.0.0.1:9000/telemetry \
+  -H 'content-type: application/json' \
+  -d '{
+        "device_id": "mac-1234",
+        "timestamp": "2024-06-10T12:00:00Z",
+        "signals": {"outbound_connections": 400},
+        "agent_id": "red-gen"
+      }'
+
+# Review generated alerts, remediations, and quota decisions
+curl -s http://127.0.0.1:9000/alerts | jq
+curl -s http://127.0.0.1:9000/remediations | jq
+curl -s http://127.0.0.1:9000/quota-updates | jq
+```
+
+When Kafka is unavailable the service degrades gracefully to API-only mode; persistent state is stored under `data/ai-soc-state.json` so the Review Board can replay alerts and LLM guidance.
+
+## 9. Repository Layout
+
+```
+.
+├── ai_soc/
+│   ├── main.py          # FastAPI AI SOC service
+│   ├── service.py       # Detection + remediation coordinator
+│   ├── kafka.py         # Optional Kafka bridge for telemetry/alerts
+│   ├── models.py        # Pydantic schemas for alerts, remediations, quota updates
+│   ├── config.py        # Environment-driven settings
+│   ├── storage.py       # JSON persistence for generated artefacts
+│   └── llm.py           # Stubbed Lumo inference wrapper
+├── hub/
+│   ├── main.py          # FastAPI entry point exposing the orchestration API
+│   ├── orchestrator.py  # Async queues and task lifecycle logic
+│   ├── models.py        # Pydantic models shared by the service
+│   └── storage.py       # JSON-backed persistence layer for demo data
+├── scripts/
+│   ├── demo.sh          # Spins up the service and walks through Red→Blue→Purple tasks
+│   ├── download.sh      # Convenience helper for fetching quantised GGUF models
+│   └── run_ai_soc.sh    # Boots the AI SOC microservice
+├── data/                # JSON store used by the demo service (auto-created)
+├── requirements.txt     # Python dependencies for the orchestration hub
+└── README.md
+```
+
+The included demo service mirrors the orchestration hub described earlier so
+that the architecture can be exercised locally without external dependencies.
+
+## 10. Key Takeaways
+
+- Modular LLM instances give each team a focused skill set with modest compute requirements.
+- Hierarchical orchestration (Red → Blue → Purple) enables continuous hardening through feedback loops.
+- The entire stack operates on macOS workstations using quantised models and container tooling, yet scales to larger infrastructures.
+- Persisting every artifact in the SIEM delivers auditability, KPI tracking, and reusable training material.
+- The architecture transforms an AI-augmented SOC into a dynamic cyber range where attackers, defenders, and evaluators co-evolve.
+

--- a/ai_soc/__init__.py
+++ b/ai_soc/__init__.py
@@ -1,0 +1,6 @@
+"""AI SOC microservice package."""
+
+from .config import Settings
+from .service import AISOCService
+
+__all__ = ["Settings", "AISOCService"]

--- a/ai_soc/config.py
+++ b/ai_soc/config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(slots=True)
+class Settings:
+    """Configuration for the AI SOC service."""
+
+    kafka_bootstrap_servers: Optional[str] = field(
+        default_factory=lambda: os.getenv("KAFKA_BOOTSTRAP_SERVERS")
+    )
+    metrics_topic: str = field(default_factory=lambda: os.getenv("KAFKA_METRICS_TOPIC", "rbp.metrics"))
+    proposals_topic: str = field(
+        default_factory=lambda: os.getenv("KAFKA_PROPOSALS_TOPIC", "rbp.proposals")
+    )
+    approvals_topic: str = field(
+        default_factory=lambda: os.getenv("KAFKA_APPROVALS_TOPIC", "rbp.approvals")
+    )
+    alerts_topic: str = field(default_factory=lambda: os.getenv("KAFKA_ALERTS_TOPIC", "rbp.alerts"))
+    quota_updates_topic: str = field(
+        default_factory=lambda: os.getenv("KAFKA_QUOTA_UPDATES_TOPIC", "rbp.quota_updates")
+    )
+    storage_path: Path = field(
+        default_factory=lambda: Path(os.getenv("AI_SOC_STORAGE", "data/ai-soc-state.json"))
+    )
+    service_name: str = field(default_factory=lambda: os.getenv("AI_SOC_SERVICE_NAME", "ai-soc"))
+    lumo_endpoint: Optional[str] = field(default_factory=lambda: os.getenv("LUMO_ENDPOINT"))
+    baseline_outbound_threshold: int = field(
+        default_factory=lambda: int(os.getenv("BASELINE_OUTBOUND_THRESHOLD", "120"))
+    )
+
+
+DEFAULT_SETTINGS = Settings()

--- a/ai_soc/kafka.py
+++ b/ai_soc/kafka.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from typing import Optional
+
+try:
+    from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+except ImportError:  # pragma: no cover - optional dependency
+    AIOKafkaConsumer = None
+    AIOKafkaProducer = None
+
+from .config import Settings
+from .models import TelemetryEvent, ThreatIntelEvent
+from .service import AISOCService
+
+LOGGER = logging.getLogger(__name__)
+
+
+class KafkaBridge:
+    """Consumes telemetry/threat intel topics and forwards alerts."""
+
+    def __init__(self, service: AISOCService, settings: Settings) -> None:
+        self._service = service
+        self._settings = settings
+        self._consumer: Optional[AIOKafkaConsumer] = None
+        self._producer: Optional[AIOKafkaProducer] = None
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        if AIOKafkaConsumer is None or self._settings.kafka_bootstrap_servers is None:
+            LOGGER.info("Kafka not configured; running in API-only mode")
+            return
+        LOGGER.info("Starting Kafka bridge on %s", self._settings.kafka_bootstrap_servers)
+        self._consumer = AIOKafkaConsumer(
+            self._settings.metrics_topic,
+            self._settings.proposals_topic,
+            self._settings.approvals_topic,
+            bootstrap_servers=self._settings.kafka_bootstrap_servers,
+            enable_auto_commit=True,
+            auto_offset_reset="earliest",
+        )
+        self._producer = AIOKafkaProducer(
+            bootstrap_servers=self._settings.kafka_bootstrap_servers,
+        )
+        await self._consumer.start()
+        await self._producer.start()
+        self._task = asyncio.create_task(self._consume_loop())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        if self._consumer:
+            await self._consumer.stop()
+        if self._producer:
+            await self._producer.stop()
+
+    async def _consume_loop(self) -> None:
+        assert self._consumer is not None
+        async for message in self._consumer:
+            try:
+                payload = json.loads(message.value.decode("utf-8"))
+            except json.JSONDecodeError:
+                LOGGER.warning("Discarding malformed message on %s", message.topic)
+                continue
+            if message.topic == self._settings.metrics_topic:
+                await self._handle_telemetry(payload)
+            elif message.topic == self._settings.proposals_topic:
+                await self._handle_threat_intel(payload)
+            elif message.topic == self._settings.approvals_topic:
+                await self._handle_approval(payload)
+
+    async def _handle_threat_intel(self, payload: dict) -> None:
+        try:
+            event = ThreatIntelEvent.model_validate(payload)
+        except Exception:
+            LOGGER.exception("Failed to parse threat intel event")
+            return
+        response = await self._service.ingest_threat_intel(event)
+        if response:
+            await self._publish_alert_response(response)
+
+    async def _handle_telemetry(self, payload: dict) -> None:
+        try:
+            event = TelemetryEvent.model_validate(payload)
+        except Exception:
+            LOGGER.exception("Failed to parse telemetry event")
+            return
+        response = await self._service.ingest_telemetry(event)
+        if response:
+            await self._publish_alert_response(response)
+
+    async def _handle_approval(self, payload: dict) -> None:
+        LOGGER.info("Received human approval payload: %s", payload)
+
+    async def _publish_alert_response(self, response) -> None:
+        if self._producer is None:
+            return
+        await self._producer.send_and_wait(
+            self._settings.alerts_topic,
+            json.dumps(response.alert.model_dump(mode="json")).encode("utf-8"),
+        )
+        if response.quota_update is not None:
+            await self._producer.send_and_wait(
+                self._settings.quota_updates_topic,
+                json.dumps(response.quota_update.model_dump(mode="json")).encode("utf-8"),
+            )

--- a/ai_soc/llm.py
+++ b/ai_soc/llm.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+from .models import Alert, RemediationAction
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LumoClient:
+    """Lightweight wrapper around the Lumo API (simulated)."""
+
+    def __init__(self, endpoint: str | None = None) -> None:
+        self._endpoint = endpoint
+
+    async def generate_remediation(self, alert: Alert) -> RemediationAction:
+        """Generate a remediation plan for a given alert."""
+
+        LOGGER.debug("Generating remediation for alert %s", alert.id)
+        actions: List[str] = [
+            f"Review telemetry for device {alert.context.get('device_id', 'unknown')}",
+            "Validate network isolation policy",
+        ]
+        policy_patch: Dict[str, str] = {
+            "apiVersion": "opa/v1",
+            "kind": "Policy",
+            "metadata": {"name": f"auto-{alert.id}"},
+            "spec": {
+                "description": alert.title,
+                "rule": "deny if outbound_connections > threshold",
+            },
+        }
+        quota_update = None
+        if alert.context.get("agent_id"):
+            quota_update = {
+                "agent_id": alert.context["agent_id"],
+                "action": "disable_self_suggest",
+                "reason": alert.description,
+            }
+
+        remediation = RemediationAction(
+            id=f"rem-{alert.id}",
+            alert_id=alert.id,
+            created_at=alert.created_at,
+            actions=actions,
+            policy_patch=policy_patch,
+            quota_update=quota_update,
+        )
+        return remediation

--- a/ai_soc/main.py
+++ b/ai_soc/main.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from fastapi import Depends, FastAPI, HTTPException
+
+from .config import DEFAULT_SETTINGS, Settings
+from .kafka import KafkaBridge
+from .llm import LumoClient
+from .models import Alert, AlertAcknowledgement, AlertResponse, TelemetryEvent, ThreatIntelEvent
+from .service import AISOCService
+from .storage import AISOCStorage
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="AI SOC Service", version="0.1.0")
+
+
+def get_settings() -> Settings:
+    return DEFAULT_SETTINGS
+
+
+def get_service(settings: Settings = Depends(get_settings)) -> AISOCService:
+    if not hasattr(app.state, "service"):
+        storage = AISOCStorage(settings.storage_path)
+        llm = LumoClient(settings.lumo_endpoint)
+        app.state.service = AISOCService(settings, storage, llm)
+    return app.state.service  # type: ignore[attr-defined]
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    settings = get_settings()
+    service = get_service(settings)
+    bridge = KafkaBridge(service, settings)
+    app.state.bridge = bridge
+    await bridge.start()
+    LOGGER.info("AI SOC service started")
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    bridge: KafkaBridge | None = getattr(app.state, "bridge", None)
+    if bridge is not None:
+        await bridge.stop()
+    LOGGER.info("AI SOC service stopped")
+
+
+@app.get("/healthz")
+async def healthz() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/threat-intel", response_model=AlertResponse | None)
+async def ingest_threat_intel(
+    payload: ThreatIntelEvent, service: AISOCService = Depends(get_service)
+) -> AlertResponse | None:
+    return await service.ingest_threat_intel(payload)
+
+
+@app.post("/telemetry", response_model=AlertResponse | None)
+async def ingest_telemetry(payload: TelemetryEvent, service: AISOCService = Depends(get_service)) -> AlertResponse | None:
+    return await service.ingest_telemetry(payload)
+
+
+@app.get("/alerts", response_model=List[Alert])
+async def list_alerts(service: AISOCService = Depends(get_service)) -> List[Alert]:
+    return service.list_alerts()
+
+
+@app.get("/alerts/{alert_id}", response_model=Alert)
+async def read_alert(alert_id: str, service: AISOCService = Depends(get_service)) -> Alert:
+    alert = service.get_alert(alert_id)
+    if alert is None:
+        raise HTTPException(status_code=404, detail="Alert not found")
+    return alert
+
+
+@app.post("/alerts/{alert_id}/ack", response_model=Alert)
+async def acknowledge_alert(
+    alert_id: str,
+    payload: AlertAcknowledgement,
+    service: AISOCService = Depends(get_service),
+) -> Alert:
+    alert = await service.acknowledge_alert(alert_id, payload)
+    if alert is None:
+        raise HTTPException(status_code=404, detail="Alert not found")
+    return alert
+
+
+@app.get("/remediations")
+async def list_remediations(service: AISOCService = Depends(get_service)):
+    return service.list_remediations()
+
+
+@app.get("/quota-updates")
+async def list_quota_updates(service: AISOCService = Depends(get_service)):
+    return service.list_quota_updates()

--- a/ai_soc/models.py
+++ b/ai_soc/models.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Severity(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+    critical = "critical"
+
+
+class AlertStatus(str, Enum):
+    open = "open"
+    acknowledged = "acknowledged"
+    resolved = "resolved"
+
+
+class ThreatIntelEvent(BaseModel):
+    source: str
+    indicator: str = Field(..., description="CVE or threat identifier")
+    summary: str
+    severity: Severity = Severity.medium
+    affected_products: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TelemetryEvent(BaseModel):
+    device_id: str
+    timestamp: datetime
+    signals: Dict[str, Any] = Field(default_factory=dict)
+    agent_id: Optional[str] = None
+
+
+class Alert(BaseModel):
+    id: str
+    created_at: datetime
+    source: str
+    title: str
+    description: str
+    severity: Severity
+    status: AlertStatus = AlertStatus.open
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RemediationAction(BaseModel):
+    id: str
+    alert_id: str
+    created_at: datetime
+    actions: List[str]
+    policy_patch: Optional[Dict[str, Any]] = None
+    quota_update: Optional[Dict[str, Any]] = None
+
+
+class QuotaUpdate(BaseModel):
+    id: str
+    agent_id: str
+    enforced_at: datetime
+    reason: str
+    self_suggest_enabled: bool
+
+
+class AlertResponse(BaseModel):
+    alert: Alert
+    remediation: Optional[RemediationAction] = None
+    quota_update: Optional[QuotaUpdate] = None
+
+
+class AlertAcknowledgement(BaseModel):
+    analyst: str
+    message: Optional[str] = None

--- a/ai_soc/service.py
+++ b/ai_soc/service.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import List, Optional
+from uuid import uuid4
+
+from .config import Settings
+from .llm import LumoClient
+from .models import (
+    Alert,
+    AlertAcknowledgement,
+    AlertResponse,
+    AlertStatus,
+    QuotaUpdate,
+    RemediationAction,
+    Severity,
+    TelemetryEvent,
+    ThreatIntelEvent,
+)
+from .storage import AISOCStorage
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AISOCService:
+    """Coordinates threat ingestion, detection, and response."""
+
+    def __init__(self, settings: Settings, storage: AISOCStorage, llm: LumoClient) -> None:
+        self._settings = settings
+        self._storage = storage
+        self._llm = llm
+        self._lock = asyncio.Lock()
+
+    async def ingest_threat_intel(self, event: ThreatIntelEvent) -> AlertResponse | None:
+        LOGGER.info("Ingesting threat intel %s from %s", event.indicator, event.source)
+        if event.severity in {Severity.high, Severity.critical}:
+            alert = await self._create_alert(
+                source="threat-intel",
+                title=f"New high-severity indicator {event.indicator}",
+                description=event.summary,
+                severity=event.severity,
+                context={"indicator": event.indicator, "source": event.source},
+            )
+            return await self._enrich_alert(alert)
+        return None
+
+    async def ingest_telemetry(self, event: TelemetryEvent) -> AlertResponse | None:
+        LOGGER.debug("Processing telemetry for device %s", event.device_id)
+        outbound = int(event.signals.get("outbound_connections", 0))
+        if outbound > self._settings.baseline_outbound_threshold:
+            alert = await self._create_alert(
+                source="telemetry",
+                title="Outbound connection spike",
+                description=(
+                    f"Device {event.device_id} exceeded outbound threshold "
+                    f"({outbound}>{self._settings.baseline_outbound_threshold})"
+                ),
+                severity=Severity.high,
+                context={
+                    "device_id": event.device_id,
+                    "agent_id": event.agent_id,
+                    "outbound_connections": outbound,
+                },
+            )
+            return await self._enrich_alert(alert)
+        return None
+
+    async def acknowledge_alert(self, alert_id: str, payload: AlertAcknowledgement) -> Alert | None:
+        alert = self._storage.get_alert(alert_id)
+        if alert is None:
+            return None
+        LOGGER.info("Alert %s acknowledged by %s", alert_id, payload.analyst)
+        alert.status = AlertStatus.acknowledged
+        alert.context.setdefault("acknowledgements", []).append(
+            {"analyst": payload.analyst, "message": payload.message, "timestamp": datetime.utcnow().isoformat()}
+        )
+        self._storage.upsert_alert(alert)
+        return alert
+
+    def list_alerts(self) -> List[Alert]:
+        return self._storage.list_alerts()
+
+    def get_alert(self, alert_id: str) -> Alert | None:
+        return self._storage.get_alert(alert_id)
+
+    def list_remediations(self) -> List[RemediationAction]:
+        return self._storage.list_remediations()
+
+    def list_quota_updates(self) -> List[QuotaUpdate]:
+        return self._storage.list_quota_updates()
+
+    async def _create_alert(
+        self,
+        *,
+        source: str,
+        title: str,
+        description: str,
+        severity: Severity,
+        context: Optional[dict] = None,
+    ) -> Alert:
+        async with self._lock:
+            alert = Alert(
+                id=str(uuid4()),
+                created_at=datetime.utcnow(),
+                source=source,
+                title=title,
+                description=description,
+                severity=severity,
+                context=context or {},
+            )
+            self._storage.upsert_alert(alert)
+            return alert
+
+    async def _enrich_alert(self, alert: Alert) -> AlertResponse:
+        remediation = await self._llm.generate_remediation(alert)
+        self._storage.upsert_remediation(remediation)
+        quota_update = None
+        if remediation.quota_update and alert.context.get("agent_id"):
+            quota_update = QuotaUpdate(
+                id=str(uuid4()),
+                agent_id=alert.context["agent_id"],
+                enforced_at=datetime.utcnow(),
+                reason=alert.description,
+                self_suggest_enabled=False,
+            )
+            self._storage.upsert_quota_update(quota_update)
+        LOGGER.debug("Generated remediation %s for alert %s", remediation.id, alert.id)
+        return AlertResponse(alert=alert, remediation=remediation, quota_update=quota_update)

--- a/ai_soc/storage.py
+++ b/ai_soc/storage.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Lock
+from typing import Dict, List
+
+from .models import Alert, QuotaUpdate, RemediationAction
+
+
+class AISOCStorage:
+    """JSON storage backend for alerts and responses."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._path.exists():
+            self._write({"alerts": {}, "remediations": {}, "quota_updates": {}})
+
+    def _read(self) -> Dict:
+        with self._path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def _write(self, payload: Dict) -> None:
+        with self._path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+
+    def upsert_alert(self, alert: Alert) -> None:
+        with self._lock:
+            data = self._read()
+            data.setdefault("alerts", {})[alert.id] = alert.model_dump(mode="json")
+            self._write(data)
+
+    def upsert_remediation(self, remediation: RemediationAction) -> None:
+        with self._lock:
+            data = self._read()
+            data.setdefault("remediations", {})[remediation.id] = remediation.model_dump(mode="json")
+            self._write(data)
+
+    def upsert_quota_update(self, update: QuotaUpdate) -> None:
+        with self._lock:
+            data = self._read()
+            data.setdefault("quota_updates", {})[update.id] = update.model_dump(mode="json")
+            self._write(data)
+
+    def list_alerts(self) -> List[Alert]:
+        with self._lock:
+            data = self._read()
+        alerts = data.get("alerts", {})
+        return [Alert.model_validate(payload) for payload in alerts.values()]
+
+    def get_alert(self, alert_id: str) -> Alert | None:
+        with self._lock:
+            data = self._read()
+        payload = data.get("alerts", {}).get(alert_id)
+        if payload is None:
+            return None
+        return Alert.model_validate(payload)
+
+    def list_remediations(self) -> List[RemediationAction]:
+        with self._lock:
+            data = self._read()
+        remediations = data.get("remediations", {})
+        return [RemediationAction.model_validate(payload) for payload in remediations.values()]
+
+    def list_quota_updates(self) -> List[QuotaUpdate]:
+        with self._lock:
+            data = self._read()
+        updates = data.get("quota_updates", {})
+        return [QuotaUpdate.model_validate(payload) for payload in updates.values()]

--- a/hub/__init__.py
+++ b/hub/__init__.py
@@ -1,0 +1,3 @@
+"""Hub package for SOC orchestration demo."""
+
+__all__ = ["main", "orchestrator", "models", "storage"]

--- a/hub/main.py
+++ b/hub/main.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.responses import JSONResponse
+
+from .models import Task, TaskCreate, TaskEnvelope, TaskResult, Team
+from .orchestrator import Orchestrator
+from .storage import TaskStorage
+
+app = FastAPI(title="LLM SOC Orchestration Hub", version="0.1.0")
+
+
+def get_orchestrator() -> Orchestrator:
+    storage_path = Path("data/task-store.json")
+    if not hasattr(app.state, "orchestrator"):
+        app.state.orchestrator = Orchestrator(TaskStorage(storage_path))
+    return app.state.orchestrator  # type: ignore[attr-defined]
+
+
+@app.post("/tasks", response_model=Task)
+async def create_task(payload: TaskCreate, orchestrator: Orchestrator = Depends(get_orchestrator)) -> Task:
+    return await orchestrator.create_task(payload)
+
+
+@app.get("/tasks/{task_id}", response_model=Task)
+async def read_task(task_id: str, orchestrator: Orchestrator = Depends(get_orchestrator)) -> Task:
+    task = orchestrator.get_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return task
+
+
+@app.get("/tasks", response_model=Dict[str, Task])
+async def list_tasks(orchestrator: Orchestrator = Depends(get_orchestrator)) -> Dict[str, Task]:
+    return orchestrator.list_tasks()
+
+
+@app.post("/tasks/{task_id}/result", response_model=Task)
+async def submit_result(
+    task_id: str,
+    payload: TaskResult,
+    orchestrator: Orchestrator = Depends(get_orchestrator),
+) -> Task:
+    task = await orchestrator.acknowledge(task_id, payload.result)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return task
+
+
+@app.post("/tasks/{task_id}/release", response_model=Task)
+async def release_task(task_id: str, orchestrator: Orchestrator = Depends(get_orchestrator)) -> Task:
+    task = await orchestrator.release(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return task
+
+
+@app.get("/queue/next", response_model=Optional[TaskEnvelope])
+async def next_task(
+    team: Team = Query(..., description="Team queue to consume from"),
+    wait: bool = Query(False, description="Long poll until a task is available"),
+    orchestrator: Orchestrator = Depends(get_orchestrator),
+) -> Optional[TaskEnvelope]:
+    envelope = await orchestrator.next_task(team=team, wait=wait)
+    if envelope is None:
+        return None
+    return envelope
+
+
+@app.get("/healthz")
+async def health_check() -> JSONResponse:
+    return JSONResponse({"status": "ok"})

--- a/hub/models.py
+++ b/hub/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Team(str, Enum):
+    red = "red"
+    blue = "blue"
+    purple = "purple"
+
+
+class TaskStatus(str, Enum):
+    queued = "queued"
+    in_progress = "in_progress"
+    completed = "completed"
+
+
+class TaskCreate(BaseModel):
+    team: Team
+    type: str = Field(..., description="Task type identifier")
+    payload: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TaskResult(BaseModel):
+    result: Dict[str, Any]
+
+
+class Task(BaseModel):
+    id: str
+    team: Team
+    type: str
+    payload: Dict[str, Any]
+    status: TaskStatus = TaskStatus.queued
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    result: Optional[Dict[str, Any]] = None
+
+    def with_status(self, status: TaskStatus) -> "Task":
+        self.status = status
+        self.updated_at = datetime.utcnow()
+        return self
+
+    def with_result(self, result: Dict[str, Any]) -> "Task":
+        self.result = result
+        self.status = TaskStatus.completed
+        self.updated_at = datetime.utcnow()
+        return self
+
+
+class TaskEnvelope(BaseModel):
+    task: Task
+    queue_position: int

--- a/hub/orchestrator.py
+++ b/hub/orchestrator.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Deque, Dict, Optional
+from uuid import uuid4
+
+from .models import Task, TaskCreate, TaskEnvelope, TaskStatus, Team
+from .storage import TaskStorage
+
+
+class Orchestrator:
+    """In-memory task queues per team with persistence hooks."""
+
+    def __init__(self, storage: TaskStorage) -> None:
+        self._storage = storage
+        self._queues: Dict[Team, Deque[str]] = {team: deque() for team in Team}
+        self._events: Dict[Team, asyncio.Event] = {team: asyncio.Event() for team in Team}
+        self._lock = asyncio.Lock()
+        self._tasks: Dict[str, Task] = {}
+        self._load_from_storage()
+
+    def _load_from_storage(self) -> None:
+        tasks = self._storage.all()
+        self._tasks = tasks
+        for task in tasks.values():
+            if task.status != TaskStatus.completed:
+                self._queues[task.team].append(task.id)
+                if task.status == TaskStatus.queued:
+                    continue
+                # Mark as queued because in-memory queue lost consumer state
+                task.with_status(TaskStatus.queued)
+        self._storage.bulk_upsert(self._tasks.values())
+
+    async def create_task(self, payload: TaskCreate) -> Task:
+        task = Task(
+            id=str(uuid4()),
+            team=payload.team,
+            type=payload.type,
+            payload=payload.payload,
+        )
+        async with self._lock:
+            self._tasks[task.id] = task
+            self._queues[task.team].append(task.id)
+            self._storage.upsert(task)
+            self._events[task.team].set()
+        return task
+
+    async def next_task(self, team: Team, *, wait: bool = False) -> Optional[TaskEnvelope]:
+        queue = self._queues[team]
+        event = self._events[team]
+        if wait:
+            while not queue:
+                event.clear()
+                await event.wait()
+        async with self._lock:
+            if not queue:
+                return None
+            task_id = queue[0]
+            task = self._tasks[task_id]
+            task.with_status(TaskStatus.in_progress)
+            self._storage.upsert(task)
+            return TaskEnvelope(task=task, queue_position=0)
+
+    async def acknowledge(self, task_id: str, result: Dict) -> Optional[Task]:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return None
+            task.with_result(result)
+            queue = self._queues[task.team]
+            if task_id in queue:
+                queue.remove(task_id)
+            self._storage.upsert(task)
+            return task
+
+    async def release(self, task_id: str) -> Optional[Task]:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return None
+            task.with_status(TaskStatus.queued)
+            queue = self._queues[task.team]
+            if task_id not in queue:
+                queue.appendleft(task_id)
+            self._storage.upsert(task)
+            self._events[task.team].set()
+            return task
+
+    def get_task(self, task_id: str) -> Optional[Task]:
+        return self._tasks.get(task_id)
+
+    def list_tasks(self) -> Dict[str, Task]:
+        return dict(self._tasks)

--- a/hub/storage.py
+++ b/hub/storage.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Lock
+from typing import Dict, Iterable
+
+from .models import Task
+
+
+class TaskStorage:
+    """Simple JSON file storage for tasks and results."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._path.exists():
+            self._write({})
+
+    def _read(self) -> Dict[str, Dict]:
+        with self._path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def _write(self, payload: Dict[str, Dict]) -> None:
+        with self._path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+
+    def upsert(self, task: Task) -> None:
+        with self._lock:
+            data = self._read()
+            data[task.id] = task.model_dump(mode="json")
+            self._write(data)
+
+    def bulk_upsert(self, tasks: Iterable[Task]) -> None:
+        with self._lock:
+            data = self._read()
+            for task in tasks:
+                data[task.id] = task.model_dump(mode="json")
+            self._write(data)
+
+    def get(self, task_id: str) -> Task | None:
+        with self._lock:
+            data = self._read()
+        payload = data.get(task_id)
+        if payload is None:
+            return None
+        return Task.model_validate(payload)
+
+    def all(self) -> Dict[str, Task]:
+        with self._lock:
+            data = self._read()
+        return {task_id: Task.model_validate(payload) for task_id, payload in data.items()}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+pydantic==2.7.1
+aiokafka==0.10.0

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${PORT:-8000}"
+HOST="${HOST:-127.0.0.1}"
+BASE_URL="http://$HOST:$PORT"
+
+python -m venv .venv >/dev/null 2>&1 || true
+source .venv/bin/activate
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+
+uvicorn hub.main:app --host "$HOST" --port "$PORT" --log-level warning &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" >/dev/null 2>&1 || true' EXIT
+
+for _ in {1..20}; do
+  if curl -fs "$BASE_URL/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.5
+done
+
+python <<'PY'
+import json
+import urllib.parse
+import urllib.request
+
+BASE_URL = "http://127.0.0.1:8000"
+
+def post(path, payload):
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        urllib.parse.urljoin(BASE_URL, path),
+        data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as response:
+        return json.load(response)
+
+
+def get(path, query=None):
+    if query:
+        path = f"{path}?{urllib.parse.urlencode(query)}"
+    with urllib.request.urlopen(urllib.parse.urljoin(BASE_URL, path)) as response:
+        return json.load(response)
+
+print("Creating sample tasks...")
+red_task = post("/tasks", {
+    "team": "red",
+    "type": "generate_scenario",
+    "payload": {"goal": "steal Documents folder"}
+})
+print("Red task:", json.dumps(red_task, indent=2))
+
+envelope = get("/queue/next", {"team": "red"})
+print("Dequeued for red team:", json.dumps(envelope, indent=2))
+
+result = post(f"/tasks/{red_task['id']}/result", {
+    "result": {"status": "scenario_generated", "scenario_id": "red-scenarios-demo"}
+})
+print("Result acknowledged:", json.dumps(result, indent=2))
+
+blue_task = post("/tasks", {
+    "team": "blue",
+    "type": "enrich_alert",
+    "payload": {"scenario_id": "red-scenarios-demo", "log_id": "alert-1"}
+})
+print("Blue task created:", json.dumps(blue_task, indent=2))
+
+envelope_blue = get("/queue/next", {"team": "blue"})
+print("Dequeued for blue team:", json.dumps(envelope_blue, indent=2))
+
+post(f"/tasks/{blue_task['id']}/result", {
+    "result": {"ml.red_match": True, "technique": "T1059"}
+})
+
+purple_task = post("/tasks", {
+    "team": "purple",
+    "type": "analyze_gap",
+    "payload": {"scenario_id": "red-scenarios-demo", "detections": ["T1059"]}
+})
+print("Purple task created:", json.dumps(purple_task, indent=2))
+
+envelope_purple = get("/queue/next", {"team": "purple"})
+print("Dequeued for purple team:", json.dumps(envelope_purple, indent=2))
+
+post(f"/tasks/{purple_task['id']}/result", {
+    "result": {"gaps": [], "summary": "All techniques detected"}
+})
+
+print("\nAll tasks:")
+print(json.dumps(get("/tasks"), indent=2))
+PY
+
+echo "Demo complete."

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  cat <<USAGE
+Usage: $(basename "$0") <model-name> [target-dir]
+
+Downloads a quantised GGUF model using curl or wget. The MODEL_BASE_URL
+environment variable can be used to override the source repository
+(defaults to llama.cpp's public Hugging Face mirror).
+USAGE
+  exit 1
+fi
+
+MODEL_NAME="$1"
+TARGET_DIR="${2:-models}"
+BASE_URL="${MODEL_BASE_URL:-https://huggingface.co/TheBloke/$MODEL_NAME/resolve/main}"
+FILENAME="${MODEL_FILE:-$MODEL_NAME.gguf}"
+
+mkdir -p "$TARGET_DIR"
+OUTPUT_PATH="$TARGET_DIR/$FILENAME"
+
+if command -v curl >/dev/null 2>&1; then
+  DOWNLOADER=(curl -Lfo)
+elif command -v wget >/dev/null 2>&1; then
+  DOWNLOADER=(wget -O)
+else
+  echo "Neither curl nor wget is available. Install one to download models." >&2
+  exit 2
+fi
+
+echo "Downloading $FILENAME from $BASE_URL"
+"${DOWNLOADER[@]}" "$OUTPUT_PATH" "$BASE_URL/$FILENAME"
+
+echo "Model saved to $OUTPUT_PATH"

--- a/scripts/run_ai_soc.sh
+++ b/scripts/run_ai_soc.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${PORT:-9000}"
+HOST="${HOST:-0.0.0.0}"
+APP="ai_soc.main:app"
+
+python -m venv .venv >/dev/null 2>&1 || true
+source .venv/bin/activate
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+
+exec uvicorn "$APP" --host "$HOST" --port "$PORT"


### PR DESCRIPTION
## Summary
- add an AI SOC FastAPI service that ingests threat intel and telemetry, enriches alerts, and coordinates remediations
- persist AI SOC artefacts to JSON storage and expose Kafka integration with optional producer/consumer bridge
- document new workflow and provide a helper script to launch the service alongside updated dependencies

## Testing
- ./scripts/demo.sh

------
https://chatgpt.com/codex/tasks/task_b_68e19c2daa2c832488da90b1c09c86ed